### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,13 @@ install:
   - conda install --yes -n test_env cython
   - source activate test_env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip https://github.com/qiime2/q2-types/archive/master.zip
+  - pip install flake8
   - pip install -e .
+  - git clone https://github.com/qiime2/q2lint
 script:
-  - WITH_COVERAGE=TRUE flake8 q2_composition setup.py
+  - nosetests
+  - WITH_COVERAGE=TRUE flake8
+  - python q2lint/q2lint.py
 notifications:
   webhooks:
     on_success: change

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -1,6 +1,5 @@
 pip
 nose
-flake8
 notebook
 scikit-bio
 scipy

--- a/q2_composition/__init__.py
+++ b/q2_composition/__init__.py
@@ -1,6 +1,17 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import pkg_resources
+
 from ._impute import add_pseudocount
 from ._ancom import ancom
 
-__version__ = '0.0.7.dev0'
+
+__version__ = pkg_resources.get_distribution('q2-composition').version
 
 __all__ = ['add_pseudocount', 'ancom']

--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -1,5 +1,13 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
 import os
-import qiime
+import qiime2
 import pandas as pd
 from skbio.stats.composition import ancom as skbio_ancom
 from skbio.stats.composition import clr
@@ -46,7 +54,7 @@ def transform_functions():
 
 def ancom(output_dir: str,
           table: pd.DataFrame,
-          metadata: qiime.MetadataCategory,
+          metadata: qiime2.MetadataCategory,
           statistical_test: str = 'f_oneway',
           transform_function: str = 'clr',
           difference_function: str = None) -> None:
@@ -67,7 +75,7 @@ def ancom(output_dir: str,
     # tuplize ancom_result to support both. Similarly, the "reject" column
     # was renamed in scikit-bio 0.5.0, so we apply a rename here (which does
     # nothing if a column called "reject" isn't found).
-    ancom_results = qiime.core.util.tuplize(ancom_results)
+    ancom_results = qiime2.core.util.tuplize(ancom_results)
     ancom_results[0].sort_values(by='W', ascending=False)
     ancom_results[0].rename(columns={'reject': 'Reject null hypothesis'},
                             inplace=True)

--- a/q2_composition/_impute.py
+++ b/q2_composition/_impute.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_composition/plugin_setup.py
+++ b/q2_composition/plugin_setup.py
@@ -1,13 +1,13 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import (SemanticType, Str, Int, Choices,
-                          MetadataCategory, Plugin)
+from qiime2.plugin import (SemanticType, Str, Int, Choices,
+                           MetadataCategory, Plugin)
 from q2_types.feature_table import (
     FeatureTable, Frequency, BIOMV100DirFmt, BIOMV210DirFmt)
 

--- a/q2_composition/tests/__init__.py
+++ b/q2_composition/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_composition/tests/test_ancom.py
+++ b/q2_composition/tests/test_ancom.py
@@ -1,4 +1,12 @@
-import qiime
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import qiime2
 from q2_composition import ancom
 import unittest
 import pandas.util.testing as pdt
@@ -27,7 +35,7 @@ class AncomTests(unittest.TestCase):
                           [9, 12, 9, 9, 9, 11]],
                          index=['O1', 'O2', 'O3', 'O4', 'O5', 'O6', 'O7'],
                          columns=['S1', 'S2', 'S3', 'S4', 'S5', 'S6']).T
-        c = qiime.MetadataCategory(
+        c = qiime2.MetadataCategory(
                 pd.Series([0, 0, 0, 1, 1, 1],
                           index=['S1', 'S2', 'S3',
                                  'S4', 'S5', 'S6']))
@@ -67,7 +75,7 @@ class AncomTests(unittest.TestCase):
                           [9, 12, 9, 9, 9, 11]],
                          index=['O1', 'O2', 'O3', 'O4', 'O5', 'O6', 'O7'],
                          columns=['S1', 'S2', 'S3', 'S4', 'S5', 'S6']).T
-        c = qiime.MetadataCategory(
+        c = qiime2.MetadataCategory(
                 pd.Series([0, 0, 1, 1, 2, 2],
                           index=['S1', 'S2', 'S3',
                                  'S4', 'S5', 'S6']))
@@ -82,6 +90,7 @@ class AncomTests(unittest.TestCase):
                                                 dtype=bool)},
             index=['O1', 'O2', 'O3', 'O4', 'O5', 'O6', 'O7'],)
         pdt.assert_frame_equal(res, exp)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/q2_composition/tests/test_impute.py
+++ b/q2_composition/tests/test_impute.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -7,32 +7,22 @@
 # ----------------------------------------------------------------------------
 
 from setuptools import setup, find_packages
-import re
-import ast
 
-# version parsing from __init__ pulled from Flask's setup.py
-# https://github.com/mitsuhiko/flask/blob/master/setup.py
-_version_re = re.compile(r'__version__\s+=\s+(.*)')
-
-with open('q2_composition/__init__.py', 'rb') as f:
-    hit = _version_re.search(f.read().decode('utf-8')).group(1)
-    version = str(ast.literal_eval(hit))
 
 setup(
     name="q2-composition",
-    version=version,
+    version="2017.2.0.dev0",
     packages=find_packages(),
-    install_requires=['qiime >= 2.0.6', 'q2-types >= 0.0.6', 'bokeh',
-                      'biom-format >= 2.1.5, < 2.2.0', 'scipy',
-                      'scikit-bio'],
+    install_requires=['qiime2 == 2017.2.*', 'q2-types == 2017.2.*', 'bokeh',
+                      'biom-format >= 2.1.5, < 2.2.0', 'scipy', 'scikit-bio'],
     package_data={'q2_composition': ['workflows/*md']},
     author="Jamie Morton",
     author_email="jamietmorton@gmail.com",
     description="Compositional statistics plugin for QIIME2.",
     license='BSD-3-Clause',
-    url="http://www.qiime.org",
+    url="https://qiime2.org",
     entry_points={
-        'qiime.plugins':
+        'qiime2.plugins':
         ['q2-composition=q2_composition.plugin_setup:plugin']
     }
 )


### PR DESCRIPTION
# ~~DO NOT MERGE~~

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0, 2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in setup.py's `install_requires` to obtain patch releases for a given train release.

The new versioning scheme is PEP 440 compliant.