### PR TITLE
ENH: Adding in multiplicative replacement

### DIFF
--- a/q2_composition/_impute.py
+++ b/q2_composition/_impute.py
@@ -5,19 +5,27 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
-
 import biom
+import numpy as np
+from skbio.stats.composition import multiplicative_replacement, closure
 
 
 def add_pseudocount(table: biom.Table,
-                    pseudocount: int=1) -> biom.Table:
+                    pseudocount: float=1,
+                    multiplicative: bool=False) -> biom.Table:
     # This is ugly, and it requires a sparse and dense representation to
     # be in memory at the same time, but biom.Table.transform only operates
     # on non-zero values, so it isn't useful here (as we need to operate on
     # all values).
-    result = biom.Table(
-        [v + pseudocount
-         for v in table.iter_data(dense=True, axis='observation')],
-        table.ids(axis='observation'),
-        table.ids())
+    if multiplicative:
+        data = [closure(multiplicative_replacement(v, delta=pseudocount))
+                for v in table.iter_data(dense=True,
+                                         axis='sample')]
+        data = np.array(data).T
+    else:
+        data = np.array([v + pseudocount
+                         for v in table.iter_data(dense=True,
+                                                  axis='observation')])
+
+    result = biom.Table(data, table.ids(axis='observation'), table.ids())
     return result

--- a/q2_composition/plugin_setup.py
+++ b/q2_composition/plugin_setup.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime2.plugin import (Str, Int, Choices,
+from qiime2.plugin import (Str, Int, Choices, Bool,
                            MetadataCategory, Plugin)
 from q2_types.feature_table import (
     FeatureTable, Frequency, BIOMV210DirFmt)
@@ -48,7 +48,8 @@ plugin.register_semantic_type_to_format(
 plugin.methods.register_function(
     function=q2_composition.add_pseudocount,
     inputs={'table': FeatureTable[Frequency]},
-    parameters={'pseudocount': Int},
+    parameters={'pseudocount': Int,
+                'multiplicative': Bool},
     outputs=[('composition_table', FeatureTable[Composition])],
     input_descriptions={
         'table': 'The feature table to which pseudocounts should be added.'

--- a/q2_composition/plugin_setup.py
+++ b/q2_composition/plugin_setup.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime2.plugin import (Str, Int, Choices, Bool,
+from qiime2.plugin import (Str, Float, Choices, Bool,
                            MetadataCategory, Plugin)
 from q2_types.feature_table import (
     FeatureTable, Frequency, BIOMV210DirFmt)
@@ -48,7 +48,7 @@ plugin.register_semantic_type_to_format(
 plugin.methods.register_function(
     function=q2_composition.add_pseudocount,
     inputs={'table': FeatureTable[Frequency]},
-    parameters={'pseudocount': Int,
+    parameters={'pseudocount': Float,
                 'multiplicative': Bool},
     outputs=[('composition_table', FeatureTable[Composition])],
     input_descriptions={

--- a/q2_composition/tests/test_impute.py
+++ b/q2_composition/tests/test_impute.py
@@ -34,6 +34,18 @@ class TestAdd_Pseudocount(unittest.TestCase):
                     ['S1', 'S2', 'S3'])
         self.assertEqual(obs, exp)
 
+    def test_add_pseudocount3(self):
+        t = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                  ['O1', 'O2'],
+                  ['S1', 'S2', 'S3'])
+        obs = add_pseudocount(t, 0.1, True)
+
+        exp = Table(np.array([[0.1, 0.5, 0.6],
+                              [0.9, 0.5, 0.4]]),
+                    ['O1', 'O2'],
+                    ['S1', 'S2', 'S3'])
+        self.assertEqual(obs, exp)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is adding a little more flexibility for the pseudocounts.  Essentially, this will allow for smaller pseudocounts to be used if necessary.  

We are adding the multiplicative flag here in order to maintain the ratios if specified.