### PR TITLE
fixed apply TypeError related to pandas 0.23 upgrade

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - bokeh
     - biom-format >=2.1.5,<2.2.0
     - scipy
+    - pandas >=0.23
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - bokeh
     - biom-format >=2.1.5,<2.2.0
     - scipy
-    - pandas >=0.23
+    - pandas >=0.23.0
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*

--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -144,7 +144,7 @@ def _volcanoplot(output_dir, table, metadata, ancom_results,
             return args
 
     # effectively doing a groupby operation wrt to the metadata
-    fold_change = transformed_table.apply(diff_func, axis=0)
+    fold_change = transformed_table.apply(diff_func)
 
     comps = None
     if not pd.isnull(fold_change).all():

--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -125,7 +125,8 @@ def _volcanoplot(output_dir, table, metadata, ancom_results,
     cats = list(set(metadata))
     transform_function_name = transform_function
     transform_function = _transform_functions[transform_function]
-    transformed_table = table.apply(transform_function, axis=1)
+    transformed_table = table.apply(
+        transform_function, axis=1, reduce=False, result_type='expand')
 
     # set default for difference_function
     if difference_function is None:
@@ -144,7 +145,7 @@ def _volcanoplot(output_dir, table, metadata, ancom_results,
             return args
 
     # effectively doing a groupby operation wrt to the metadata
-    fold_change = transformed_table.apply(diff_func)
+    fold_change = transformed_table.apply(diff_func, axis=0)
 
     comps = None
     if not pd.isnull(fold_change).all():


### PR DESCRIPTION
fixes #54 

Seems that the pandas 0.23 upgrade must change the default format output by `DataFrame.apply`, so that [this line](https://github.com/qiime2/q2-composition/blob/master/q2_composition/_ancom.py#L128) now generates a `Series`, not a `DataFrame`. 

`Series.apply` ([this line](https://github.com/qiime2/q2-composition/blob/master/q2_composition/_ancom.py#L147)) does [not](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.apply.html#pandas.Series.apply) have an `axis` parameter, leading to our error:

```
TypeError: diff_func() got an unexpected keyword argument 'axis'
```

So just tell `DataFrame.apply` to produce a dataframe (as I believe was the default in the past) and everything's copacetic. 😌 

**ALL TESTS PASS LOCALLY** 🎉 