### PR TITLE
Downgrade pandas to <0.23 instead of >=0.23

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - bokeh
     - biom-format >=2.1.5,<2.2.0
     - scipy
-    - pandas >=0.23.0
+    - pandas <0.23.0
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*

--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -125,8 +125,11 @@ def _volcanoplot(output_dir, table, metadata, ancom_results,
     cats = list(set(metadata))
     transform_function_name = transform_function
     transform_function = _transform_functions[transform_function]
+
+    # broadcast is deprecated in pandas>=0.23 and should be replaced for
+    # result_type='expand'
     transformed_table = table.apply(
-        transform_function, axis=1, reduce=False, result_type='expand')
+        transform_function, axis=1, reduce=False, broadcast=False)
 
     # set default for difference_function
     if difference_function is None:


### PR DESCRIPTION
This allows for other packages (namely scikit-bio 0.5.3) to be compatible with current QIIME2-dev distribution.

In the long run we want to make our dependency on pandas more flexible i.e. not limited to <0.23 but that will require a fair amount of changes in scikit-bio. If this PR is merged, I'll open an issue (in this repo) to keep track of this and make sure we don't forget to re-allow for pandas >=0.23

Related to https://github.com/qiime2/q2-types/pull/191
