### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/q2_composition/_impute.py
+++ b/q2_composition/_impute.py
@@ -10,7 +10,7 @@ import biom
 
 
 def add_pseudocount(table: biom.Table,
-                    pseudocount: int=1) -> biom.Table:
+                    pseudocount: int = 1) -> biom.Table:
     # This is ugly, and it requires a sparse and dense representation to
     # be in memory at the same time, but biom.Table.transform only operates
     # on non-zero values, so it isn't useful here (as we need to operate on

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Minor updates for compliance with flake8 v3.6, as discussed in qiime2/qiime2#415
Note: flake8 has been disabled in versioneer.py.