### PR TITLE
BUG: invalid index reference

### DIFF
--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -132,7 +132,7 @@ def ancom(output_dir: str,
                        'fill': {'value': 'black'},
                        'opacity': {'value': 0.3},
                        'tooltip': {
-                           'signal': "{{'title': datum['index'], '{0}': "
+                           'signal': "{{'title': datum['id'], '{0}': "
                                      "datum['{0}'], 'W': datum['W']}}".format(
                                          transform_function_name)}}}}]}
         context['vega_spec'] = json.dumps(spec)


### PR DESCRIPTION
This bug was apparently introduced in #66, by changing the index label from "index" to "id", and not updating the vega spec as necessary.

Forum x-ref: https://forum.qiime2.org/t/ancom-detail-difference-between-2018-8-and-2019-10/12824