### PR TITLE
Automatically drop `NaN` values when executing `ancom.py`

### DIFF
--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -51,8 +51,6 @@ def ancom(output_dir: str,
         logging.info('Metadata column is missing values for the '
                      'following samples. Values %s are excluded from ' 
                      'analysis.' % missing_data_sids)
-        # Removing empty values from analysis 
-        table = table.drop(index=missing_data_sids)
         metadata = metadata.to_series().drop(missing_data_sids)
         # raise ValueError('Metadata column is missing values for the '
         #                  'following samples. Values need to be added for '

--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -60,7 +60,7 @@ def ancom(output_dir: str,
         #                  'from the table: %s' % missing_data_sids)
     else: 
         metadata = metadata.to_series()
-        
+
     ancom_results = skbio_ancom(table,
                                 metadata,
                                 significance_test=f_oneway)
@@ -77,7 +77,6 @@ def ancom(output_dir: str,
         context['percent_abundances'] = q2templates.df_to_html(
             ancom_results[1].loc[significant_features.index])
 
-    metadata = metadata.to_series()
     cats = list(set(metadata))
     transform_function_name = transform_function
     transform_function = _transform_functions[transform_function]

--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -21,6 +21,9 @@ from skbio.stats.composition import clr
 from numpy import log, sqrt
 from scipy.stats import f_oneway
 
+logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+logger = logging.getLogger('ANCOM')
+
 _difference_functions = {'mean_difference': lambda x, y: x.mean() - y.mean(),
                          'f_statistic': f_oneway}
 

--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -51,6 +51,7 @@ def ancom(output_dir: str,
     if metadata.has_missing_values():
         missing_data_sids = metadata.get_ids(where_values_missing=True)
         metadata = metadata.to_series().drop(missing_data_sids)
+        table = table.drop(index=missing_data_sids)
         missing_data_sids = ', '.join(sorted(missing_data_sids))
         logging.info('Metadata column is missing values for the '
                      'following samples. Values %s are excluded from ' 

--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -50,11 +50,12 @@ def ancom(output_dir: str,
     metadata = metadata.filter_ids(table.index)
     if metadata.has_missing_values():
         missing_data_sids = metadata.get_ids(where_values_missing=True)
+        metadata = metadata.to_series().drop(missing_data_sids)
         missing_data_sids = ', '.join(sorted(missing_data_sids))
         logging.info('Metadata column is missing values for the '
                      'following samples. Values %s are excluded from ' 
                      'analysis.' % missing_data_sids)
-        metadata = metadata.to_series().drop(missing_data_sids)
+        
         # raise ValueError('Metadata column is missing values for the '
         #                  'following samples. Values need to be added for '
         #                  'these samples, or the samples need to be removed '

--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -53,14 +53,10 @@ def ancom(output_dir: str,
         metadata = metadata.to_series().drop(missing_data_sids)
         table = table.drop(index=missing_data_sids)
         missing_data_sids = ', '.join(sorted(missing_data_sids))
-        logging.info('Metadata column is missing values for the '
-                     'following samples. Values %s are excluded from ' 
+        logging.info('Metadata column is missing values for '
+                     'samples  %s. These samples are excluded from ' 
                      'analysis.' % missing_data_sids)
-        
-        # raise ValueError('Metadata column is missing values for the '
-        #                  'following samples. Values need to be added for '
-        #                  'these samples, or the samples need to be removed '
-        #                  'from the table: %s' % missing_data_sids)
+                     
     else: 
         metadata = metadata.to_series()
 

--- a/q2_composition/_ancom.py
+++ b/q2_composition/_ancom.py
@@ -58,6 +58,9 @@ def ancom(output_dir: str,
         #                  'following samples. Values need to be added for '
         #                  'these samples, or the samples need to be removed '
         #                  'from the table: %s' % missing_data_sids)
+    else: 
+        metadata = metadata.to_series()
+        
     ancom_results = skbio_ancom(table,
                                 metadata,
                                 significance_test=f_oneway)

--- a/q2_composition/tests/test_ancom.py
+++ b/q2_composition/tests/test_ancom.py
@@ -179,7 +179,7 @@ class AncomTests(TestPluginBase):
         # Testing if test produces an output and info when 
         # metadata contains empty values
         t = pd.DataFrame([[10, 2], [11, 2], [12, 4], [13, 5],
-                          [1000, 10], [1000, 10]],
+                          [1000, 12], [1000, 14]],
                          index=['S1', 'S2', 'S3', 'S4', 'S5', 'S6'],
                          columns=['O1', 'O2'])
         c = qiime2.CategoricalMetadataColumn(

--- a/q2_composition/tests/test_ancom.py
+++ b/q2_composition/tests/test_ancom.py
@@ -175,6 +175,25 @@ class AncomTests(TestPluginBase):
             self.assertTrue(
                 'non-numeric results:\n    <strong>O2</strong>' in f)
 
+    def test_ancom_nan_values_metadata(self):
+        # Testing if test produces an output and info when 
+        # metadata contains empty values
+        t = pd.DataFrame([[10, 0], [11, 0], [12, 0], [13, 0],
+                          [1000, 10], [1000, 10]],
+                         index=['S1', 'S2', 'S3', 'S4', 'S5', 'S6'],
+                         columns=['O1', 'O2'])
+        c = qiime2.CategoricalMetadataColumn(
+            pd.Series(['0', '0', '1', '1', np.nan, np.nan], name='n',
+                      index=pd.Index(['S1', 'S2', 'S3', 'S4', 'S5', 'S6'],
+                                     name='id'))
+        )
+
+        ancom(output_dir=self.temp_dir.name, table=t+1, metadata=c)
+
+        index_fp = os.path.join(self.temp_dir.name, 'index.html')
+        self.assertTrue(os.path.exists(index_fp))
+        self.assertTrue(os.path.getsize(index_fp) > 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/q2_composition/tests/test_ancom.py
+++ b/q2_composition/tests/test_ancom.py
@@ -178,7 +178,7 @@ class AncomTests(TestPluginBase):
     def test_ancom_nan_values_metadata(self):
         # Testing if test produces an output and info when 
         # metadata contains empty values
-        t = pd.DataFrame([[10, 0], [11, 0], [12, 0], [13, 0],
+        t = pd.DataFrame([[10, 2], [11, 2], [12, 4], [13, 5],
                           [1000, 10], [1000, 10]],
                          index=['S1', 'S2', 'S3', 'S4', 'S5', 'S6'],
                          columns=['O1', 'O2'])


### PR DESCRIPTION
During the analysis, I had some missing metadata values. To counter it I had to:
-  revert to a `feature-table` step 
- `filter` it, filter than `collapse` it
- `add_pseudocount`
- filter metadata 
- finally run `ancom`    

Missing values in metadata are human-introduced errors, they appear quite often. This is an inconvenient workflow for the user. 

Instead of raising an error when metadata has `nan` entries, I propose ANCOM would proceed and inform the user which samples were excluded from analysis if any. 

![image](https://user-images.githubusercontent.com/61702053/152781940-4a7ab4a9-6c59-464a-8aca-4390b43beabb.png)