### PR TITLE
BUG: single ref level string splitting in tabulate viz

### DIFF
--- a/q2_composition/_ancombc.py
+++ b/q2_composition/_ancombc.py
@@ -99,15 +99,27 @@ def _ancombc(table, metadata, formula, p_adj_method, prv_cut, lib_cut,
         for term in formula_terms:
             if isinstance(metadata.get_column(term),
                           CategoricalMetadataColumn):
-                term_alpha_value = (metadata.get_column(term).to_dataframe()
+                term_alpha_value = (metadata.get_column(term)
+                                    .to_dataframe()
                                     .sort_values(term)[term][0])
                 ref_level_pair = term + '::' + str(term_alpha_value)
                 reference_levels.append(ref_level_pair)
 
     # column & level validation for the reference_levels parameter
+    reference_level_columns = []
     for i in reference_levels:
         column = i.split('::')[0]
         level_value = i.split('::')[1]
+        # check that multiple values for the same column aren't provided
+        if column in reference_level_columns:
+            raise ValueError('Multiple `reference_level` pairs with the same'
+                             ' column were provided. Please only include one'
+                             ' `reference_level` pair per column from the'
+                             ' terms in the formula. `reference_level` column'
+                             ' with multiple groups that was included:'
+                             ' "%s"' % term)
+        else:
+            reference_level_columns.append(column)
 
         # check that reference_level columns are present in the metadata
         ref_column = metadata.get_column(column)

--- a/q2_composition/_ancombc.py
+++ b/q2_composition/_ancombc.py
@@ -101,7 +101,7 @@ def _ancombc(table, metadata, formula, p_adj_method, prv_cut, lib_cut,
                           CategoricalMetadataColumn):
                 term_alpha_value = (metadata.get_column(term).to_dataframe()
                                     .sort_values(term)[term][0])
-                ref_level_pair = str(term + '::' + str(term_alpha_value))
+                ref_level_pair = term + '::' + str(term_alpha_value)
                 reference_levels.append(ref_level_pair)
 
     # column & level validation for the reference_levels parameter

--- a/q2_composition/_ancombc.py
+++ b/q2_composition/_ancombc.py
@@ -91,12 +91,16 @@ def _ancombc(table, metadata, formula, p_adj_method, prv_cut, lib_cut,
 
     md_column_types = {}
     for name, attrs in metadata.columns.items():
+        # MetadataColumn type
         if attrs[0] == 'numeric':
             md_column_types[name] = 'numeric'
         elif attrs[0] == 'categorical':
             md_column_types[name] = 'categorical'
+        # deadman switch in case we ever add any other md column types
         else:
-            pass
+            raise TypeError('Unexpected MetadataColumn type: "%s"'
+                            ' Expected types are either "categorical" or'
+                            ' "numeric".' % attrs[0])
 
     md_column_types_json = json.dumps(md_column_types)
 

--- a/q2_composition/_ancombc.py
+++ b/q2_composition/_ancombc.py
@@ -105,6 +105,9 @@ def _ancombc(table, metadata, formula, p_adj_method, prv_cut, lib_cut,
                 ref_level_pair = term + '::' + str(term_alpha_value)
                 reference_levels.append(ref_level_pair)
 
+    if isinstance(reference_levels, str):
+        reference_levels = [reference_levels]
+
     # column & level validation for the reference_levels parameter
     reference_level_columns = []
     for i in reference_levels:

--- a/q2_composition/_ancombc.py
+++ b/q2_composition/_ancombc.py
@@ -87,6 +87,12 @@ def _ancombc(table, metadata, formula, p_adj_method, prv_cut, lib_cut,
              reference_levels, neg_lb, tol, max_iter, conserve, alpha):
 
     meta = metadata.to_dataframe()
+    # TODO: add list of column types for handling in ANCOMBC
+    # so that columns with numbers that are set as categorical
+    # aren't treated as numeric
+    # for k, v in metadata.columns.items():
+    #     print(k)
+    #     print(v[0])
 
     # error on IDs found in table but not in metadata
     missing_ids = table.index.difference(meta.index).values

--- a/q2_composition/_dataloaf_tabulate/_visualizer.py
+++ b/q2_composition/_dataloaf_tabulate/_visualizer.py
@@ -45,15 +45,20 @@ def tabulate(output_dir: str, data: DataLoafPackageDirFmt):
         slice_contents.append(slice_html)
 
     slice_tables = zip(slice_names, slice_contents)
+
     # Filling in the table that will appear on index.html
-    if len([slice_md_json['metadata']['intercept_groups']]) == 1:
+    intercept = slice_md_json['metadata']['intercept_groups']
+    if isinstance(intercept, str):
+        intercept = [intercept]
+
+    if len(intercept) == 1:
         context = {
-            'intercept_single': slice_md_json['metadata']['intercept_groups'],
+            'intercept_single': intercept[0],
             'tables': slice_tables
         }
     else:
         context = {
-            'intercept_multi': slice_md_json['metadata']['intercept_groups'],
+            'intercept_multi': intercept,
             'tables': slice_tables
         }
     # Render the results using q2templates

--- a/q2_composition/_dataloaf_tabulate/_visualizer.py
+++ b/q2_composition/_dataloaf_tabulate/_visualizer.py
@@ -46,10 +46,15 @@ def tabulate(output_dir: str, data: DataLoafPackageDirFmt):
 
     slice_tables = zip(slice_names, slice_contents)
     # Filling in the table that will appear on index.html
-    context = {
-        'intercept': slice_md_json['metadata']['intercept_groups'],
-        'tables': slice_tables
-    }
-
+    if len([slice_md_json['metadata']['intercept_groups']]) == 1:
+        context = {
+            'intercept_single': slice_md_json['metadata']['intercept_groups'],
+            'tables': slice_tables
+        }
+    else:
+        context = {
+            'intercept_multi': slice_md_json['metadata']['intercept_groups'],
+            'tables': slice_tables
+        }
     # Render the results using q2templates
     q2templates.render(index, output_dir, context=context)

--- a/q2_composition/_dataloaf_tabulate/assets/index.html
+++ b/q2_composition/_dataloaf_tabulate/assets/index.html
@@ -92,7 +92,7 @@
       {% if name == "lfc" %}
         <h1>Log-Fold Change (LFC)</h1>
           <p>Positive numbers indicate enrichment relative to the intercept,
-          negative numbers indicate depletion relative to the intercept.</p>
+          negative numbers indicate depletion relative to the intercept.</p><br>
       {% elif name == "p_val" %}
         <h1><i>p</i>-Values</h1>
       {% elif name == "q_val" %}
@@ -105,9 +105,11 @@
         <h1>{{ name }}</h1>
       {% endif %}
       {% if intercept_single %}
-        <p>Groups used to define the intercept: {{ intercept_single }} (and any numerical metadata columns)</p>
+        <p><b>Groups used to define the intercept:</b></p>
+        <p>{{ intercept_single }} (and any numerical metadata columns)</p>
       {% else %}
-        <p>Groups used to define the intercept: {{ ", ".join(intercept_multi) }} (and any numerical metadata columns)</p>
+        <p><b>Groups used to define the intercept:</b></p>
+        <p>{{ ", ".join(intercept_multi) }} (and any numerical metadata columns)</p>
       {% endif %}
       <table class="dataframe table table-striped table-hover" border="0">{{ table }}</table>
       </div>

--- a/q2_composition/_dataloaf_tabulate/assets/index.html
+++ b/q2_composition/_dataloaf_tabulate/assets/index.html
@@ -96,7 +96,7 @@
       {% elif name == "p_val" %}
         <h1><i>p</i>-Values</h1>
       {% elif name == "q_val" %}
-        <h1><i>q</i>-Values</h1>
+        <h1><i>q</i>-Values: FDR Corrected <i>p</i>-Values</h1>
       {% elif name == "se" %}
         <h1>Standard Error</h1>
       {% elif name == "w" %}

--- a/q2_composition/_dataloaf_tabulate/assets/index.html
+++ b/q2_composition/_dataloaf_tabulate/assets/index.html
@@ -104,7 +104,11 @@
       {% else %}
         <h1>{{ name }}</h1>
       {% endif %}
-      <p>Groups used to define the intercept: {{ ", ".join(intercept) }} (and any numerical metadata columns)</p>
+      {% if intercept_single %}
+        <p>Groups used to define the intercept: {{ intercept_single }} (and any numerical metadata columns)</p>
+      {% else %}
+        <p>Groups used to define the intercept: {{ ", ".join(intercept_multi) }} (and any numerical metadata columns)</p>
+      {% endif %}
       <table class="dataframe table table-striped table-hover" border="0">{{ table }}</table>
       </div>
     {% endfor %}

--- a/q2_composition/assets/run_ancombc.R
+++ b/q2_composition/assets/run_ancombc.R
@@ -80,25 +80,25 @@ if (!file.exists(inp_metadata_path)) {
   errQuit("Metadata file path does not exist.")
 } else {
   metadata_file <- read.delim(inp_metadata_path, check.names = FALSE,
-                              fill = TRUE, header = TRUE)
+                              row.names = 1)
   }
 
 # convert column types to numeric/categorical as specified in metadata
+md <- sample_data(metadata_file)
+row.names(md) <- rownames(metadata_file)
 md_column_types <- fromJSON(md_column_types)
 
 for (i in seq(1, length(md_column_types))) {
   if (md_column_types[i] == "numeric") {
-    metadata_file[[names(md_column_types[i])]] <-
-      as.numeric(metadata_file[[names(md_column_types[i])]])
+    md[[names(md_column_types[i])]] <-
+      as.numeric(md[[names(md_column_types[i])]])
   } else if (md_column_types[i] == "categorical") {
-    metadata_file[[names(md_column_types[i])]] <-
-      as.character(metadata_file[[names(md_column_types[i])]])
+    md[[names(md_column_types[i])]] <-
+      as.character(md[[names(md_column_types[i])]])
   }
 }
 
 otu <- otu_table(otu_file, taxa_are_rows = TRUE)
-md <- sample_data(metadata_file)
-row.names(md) <- rownames(metadata_file)
 
 intercept_groups <- c()
 # split the reference_levels param into each column and associated level order

--- a/q2_composition/assets/run_ancombc.R
+++ b/q2_composition/assets/run_ancombc.R
@@ -82,34 +82,28 @@ otu <- otu_table(otu_file, taxa_are_rows = TRUE)
 md <- sample_data(metadata_file)
 row.names(md) <- rownames(metadata_file)
 
-if (reference_levels == "") {
-  reference_levels <- NULL
-}
-
 intercept_groups <- c()
 # split the reference_levels param into each column and associated level order
-if (!is.null(reference_levels)) {
-  level_vectors <- unlist(strsplit(reference_levels, ", "))
+level_vectors <- unlist(strsplit(reference_levels, ", "))
 
-  for (i in level_vectors) {
-    column <- unlist(strsplit(i, "::"))[1]
-    column <- gsub("\\'", "", column)
-    column <- gsub("\\]", "", column)
-    column <- gsub("\\[", "", column)
+for (i in level_vectors) {
+  column <- unlist(strsplit(i, "::"))[1]
+  column <- gsub("\\'", "", column)
+  column <- gsub("\\]", "", column)
+  column <- gsub("\\[", "", column)
 
-    intercept_vector <- unlist(strsplit(i, "::"))[2]
-    intercept_vector <- unlist(strsplit(intercept_vector, ","))
-    intercept_vector <- gsub("\\'", "", intercept_vector)
-    intercept_vector <- gsub("\\]", "", intercept_vector)
-    intercept_vector <- gsub("\\[", "", intercept_vector)
+  intercept_vector <- unlist(strsplit(i, "::"))[2]
+  intercept_vector <- unlist(strsplit(intercept_vector, ","))
+  intercept_vector <- gsub("\\'", "", intercept_vector)
+  intercept_vector <- gsub("\\]", "", intercept_vector)
+  intercept_vector <- gsub("\\[", "", intercept_vector)
 
-    intercept_groups <- append(intercept_groups,
-                               paste(column, intercept_vector, sep = "::"))
+  intercept_groups <- append(intercept_groups,
+                              paste(column, intercept_vector, sep = "::"))
 
-    # handling formula input(s)
-    md[[column]] <- factor(md[[column]])
-    md[[column]] <- relevel(md[[column]], ref = intercept_vector)
-  }
+  # handling formula input(s)
+  md[[column]] <- factor(md[[column]])
+  md[[column]] <- relevel(md[[column]], ref = intercept_vector)
 }
 
 # create phyloseq object for use in ancombc

--- a/q2_composition/tests/test_ancombc.py
+++ b/q2_composition/tests/test_ancombc.py
@@ -53,7 +53,80 @@ class TestANCOMBC(TestBase):
             ancombc(table=self.table, metadata=self.missing_md,
                     formula='bodysite')
 
-    # confirm level ordering behavior
+    # confirm output columns based on formula inputs and ref levels
+    def test_output_cols_single_formula_no_ref_level(self):
+        # should see the alphabetical ref level group removed
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite')
+
+        slices = dataloaf.data_slices.iter_views(pd.DataFrame)
+        for _, slice in slices:
+            for col in slice.columns:
+                self.assertNotIn('bodysitegut', col)
+
+    def test_output_cols_single_formula_single_ref_level(self):
+        # should see the chosen ref level group removed
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite',
+                           reference_levels=['bodysite::tongue'])
+
+        slices = dataloaf.data_slices.iter_views(pd.DataFrame)
+        for _, slice in slices:
+            for col in slice.columns:
+                self.assertNotIn('bodysitetongue', col)
+
+    def test_output_cols_single_formula_multi_ref_levels(self):
+        # should see the chosen ref level groups removed
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite',
+                           reference_levels=['bodysite::tongue',
+                                             'bodysite::left palm'])
+
+        slices = dataloaf.data_slices.iter_views(pd.DataFrame)
+        for _, slice in slices:
+            for col in slice.columns:
+                self.assertNotIn('bodysitetongue', col)
+                self.assertNotIn('bodysiteleft palm', col)
+
+    def test_output_cols_multi_formula_no_ref_level(self):
+        # should see each formula term's alphabetical ref level groups removed
+        # TODO: also check that column groups from both formula terms exist
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite + animal')
+
+        slices = dataloaf.data_slices.iter_views(pd.DataFrame)
+        for _, slice in slices:
+            for col in slice.columns:
+                self.assertNotIn('bodysitegut', col)
+                self.assertNotIn('animalbird', col)
+
+    def test_output_cols_multi_formula_single_ref_level(self):
+        # should see the chosen formula term's ref level group removed
+        # as well as the alphabetical ref level group for any terms left out
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite + animal',
+                           reference_levels=['bodysite::tongue'])
+
+        slices = dataloaf.data_slices.iter_views(pd.DataFrame)
+        for _, slice in slices:
+            for col in slice.columns:
+                self.assertNotIn('bodysitetongue', col)
+                self.assertNotIn('animalbird', col)
+
+    def test_output_cols_multi_formula_multi_ref_levels(self):
+        # should see the chosen formula terms ref level groups removed
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite + animal',
+                           reference_levels=['bodysite::tongue',
+                                             'animal::dog'])
+
+        slices = dataloaf.data_slices.iter_views(pd.DataFrame)
+        for _, slice in slices:
+            for col in slice.columns:
+                self.assertNotIn('bodysitetongue', col)
+                self.assertNotIn('animaldog', col)
+
+    # confirm ref level behavior
     def test_ref_levels_behavior_A(self):
         dataloaf = ancombc(table=self.table, metadata=self.md,
                            formula='bodysite + AZcolumn',

--- a/q2_composition/tests/test_ancombc.py
+++ b/q2_composition/tests/test_ancombc.py
@@ -55,9 +55,9 @@ class TestANCOMBC(TestBase):
 
     # confirm output columns based on formula inputs and ref levels
     def test_output_cols_single_formula_no_ref_level(self):
-        exp_col_list = ['id', '(Intercept)', 'bodysiteleft palm',
-                        'bodysiteright palm', 'bodysitetongue']
-        obs_col_list = []
+        exp_cols = set(['id', '(Intercept)', 'bodysiteleft palm',
+                        'bodysiteright palm', 'bodysitetongue'])
+        obs_cols = set()
 
         dataloaf = ancombc(table=self.table, metadata=self.md,
                            formula='bodysite')
@@ -65,15 +65,15 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                obs_col_list.append(col)
+                obs_cols.append(col)
                 self.assertNotIn('bodysitegut', col)
 
-        self.assertEqual(set(exp_col_list), set(obs_col_list))
+        self.assertEqual(exp_cols, obs_cols)
 
     def test_output_cols_single_formula_single_ref_level(self):
-        exp_col_list = ['id', '(Intercept)', 'bodysiteleft palm',
-                        'bodysiteright palm', 'bodysitegut']
-        obs_col_list = []
+        exp_cols = set(['id', '(Intercept)', 'bodysiteleft palm',
+                       'bodysiteright palm', 'bodysitegut'])
+        obs_cols = set()
         dataloaf = ancombc(table=self.table, metadata=self.md,
                            formula='bodysite',
                            reference_levels=['bodysite::tongue'])
@@ -81,16 +81,16 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                obs_col_list.append(col)
+                obs_cols.append(col)
                 self.assertNotIn('bodysitetongue', col)
 
-        self.assertEqual(set(exp_col_list), set(obs_col_list))
+        self.assertEqual(exp_cols, obs_cols)
 
     def test_output_cols_multi_formula_no_ref_level(self):
-        exp_col_list = ['id', '(Intercept)', 'bodysiteleft palm',
+        exp_cols = set(['id', '(Intercept)', 'bodysiteleft palm',
                         'bodysiteright palm', 'bodysitetongue',
-                        'animalcat', 'animalcow', 'animaldog']
-        obs_col_list = []
+                        'animalcat', 'animalcow', 'animaldog'])
+        obs_cols = set()
 
         dataloaf = ancombc(table=self.table, metadata=self.md,
                            formula='bodysite + animal')
@@ -98,17 +98,17 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                obs_col_list.append(col)
+                obs_cols.append(col)
                 self.assertNotIn('bodysitegut', col)
                 self.assertNotIn('animalbird', col)
 
-        self.assertEqual(set(exp_col_list), set(obs_col_list))
+        self.assertEqual(exp_cols, obs_cols)
 
     def test_output_cols_multi_formula_single_ref_level(self):
-        exp_col_list = ['id', '(Intercept)', 'bodysiteleft palm',
+        exp_cols = set(['id', '(Intercept)', 'bodysiteleft palm',
                         'bodysiteright palm', 'bodysitegut',
-                        'animalcat', 'animalcow', 'animaldog']
-        obs_col_list = []
+                        'animalcat', 'animalcow', 'animaldog'])
+        obs_cols = set()
 
         dataloaf = ancombc(table=self.table, metadata=self.md,
                            formula='bodysite + animal',
@@ -117,17 +117,17 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                obs_col_list.append(col)
+                obs_cols.append(col)
                 self.assertNotIn('bodysitetongue', col)
                 self.assertNotIn('animalbird', col)
 
-        self.assertEqual(set(exp_col_list), set(obs_col_list))
+        self.assertEqual(exp_cols, obs_cols)
 
     def test_output_cols_multi_formula_multi_ref_levels(self):
-        exp_col_list = ['id', '(Intercept)', 'bodysiteleft palm',
+        exp_cols = set(['id', '(Intercept)', 'bodysiteleft palm',
                         'bodysiteright palm', 'bodysitegut',
-                        'animalcat', 'animalcow', 'animalbird']
-        obs_col_list = []
+                        'animalcat', 'animalcow', 'animalbird'])
+        obs_cols = set()
 
         dataloaf = ancombc(table=self.table, metadata=self.md,
                            formula='bodysite + animal',
@@ -137,11 +137,11 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                obs_col_list.append(col)
+                obs_cols.append(col)
                 self.assertNotIn('bodysitetongue', col)
                 self.assertNotIn('animaldog', col)
 
-        self.assertEqual(set(exp_col_list), set(obs_col_list))
+        self.assertEqual(exp_cols, obs_cols)
 
     # confirm ref level behavior
     def test_ref_levels_behavior_A(self):
@@ -170,9 +170,9 @@ class TestANCOMBC(TestBase):
                            reference_levels=['bodysite::tongue',
                                              'month::10'])
 
-        exp_col_list = ['id', '(Intercept)', 'bodysitegut',
-                        'bodysiteleft palm', 'bodysiteright palm',
-                        'month1', 'month2', 'month3', 'month4']
+        exp_cols = set('id', '(Intercept)', 'bodysitegut',
+                       'bodysiteleft palm', 'bodysiteright palm',
+                       'month1', 'month2', 'month3', 'month4')
 
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
 
@@ -180,7 +180,7 @@ class TestANCOMBC(TestBase):
             col_list = []
             for col in slice.columns:
                 col_list.append(col)
-                self.assertIn(col, exp_col_list)
+                self.assertIn(col, exp_cols)
 
             self.assertNotIn('bodysitetongue', col_list)
             self.assertNotIn('month10', col_list)
@@ -210,3 +210,9 @@ class TestANCOMBC(TestBase):
                                     ' "bodysite"'):
             ancombc(table=self.table, metadata=self.md, formula='bodysite',
                     reference_levels=['bodysite::tongue', 'bodysite::toe'])
+
+    def test_extra_col_value_separator_in_ref_level_failure(self):
+        with self.assertRaisesRegex(ValueError, 'Too many column-value pair'
+                                    ' separators found.*"bodysite::tongue::"'):
+            ancombc(table=self.table, metadata=self.md, formula='bodysite',
+                    reference_levels=['bodysite::tongue::'])

--- a/q2_composition/tests/test_ancombc.py
+++ b/q2_composition/tests/test_ancombc.py
@@ -77,6 +77,8 @@ class TestANCOMBC(TestBase):
 
     def test_output_cols_single_formula_multi_ref_levels(self):
         # should see the chosen ref level groups removed
+        # TODO: the highest alphabetically ordered group is the one removed
+        # but the other group(s) remain - is this expected? How to handle?
         dataloaf = ancombc(table=self.table, metadata=self.md,
                            formula='bodysite',
                            reference_levels=['bodysite::tongue',
@@ -85,8 +87,9 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                self.assertNotIn('bodysitetongue', col)
-                self.assertNotIn('bodysiteleft palm', col)
+                print(col)
+                # self.assertNotIn('bodysitetongue', col)
+                # self.assertNotIn('bodysiteleft palm', col)
 
     def test_output_cols_multi_formula_no_ref_level(self):
         # should see each formula term's alphabetical ref level groups removed

--- a/q2_composition/tests/test_ancombc.py
+++ b/q2_composition/tests/test_ancombc.py
@@ -65,7 +65,7 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                obs_cols.append(col)
+                obs_cols.add(col)
                 self.assertNotIn('bodysitegut', col)
 
         self.assertEqual(exp_cols, obs_cols)
@@ -81,7 +81,7 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                obs_cols.append(col)
+                obs_cols.add(col)
                 self.assertNotIn('bodysitetongue', col)
 
         self.assertEqual(exp_cols, obs_cols)
@@ -98,7 +98,7 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                obs_cols.append(col)
+                obs_cols.add(col)
                 self.assertNotIn('bodysitegut', col)
                 self.assertNotIn('animalbird', col)
 
@@ -117,7 +117,7 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                obs_cols.append(col)
+                obs_cols.add(col)
                 self.assertNotIn('bodysitetongue', col)
                 self.assertNotIn('animalbird', col)
 
@@ -137,9 +137,26 @@ class TestANCOMBC(TestBase):
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
         for _, slice in slices:
             for col in slice.columns:
-                obs_cols.append(col)
+                obs_cols.add(col)
                 self.assertNotIn('bodysitetongue', col)
                 self.assertNotIn('animaldog', col)
+
+        self.assertEqual(exp_cols, obs_cols)
+
+    # testing type directive in md for categorical columns w/numeric values
+    def test_output_cols_categorical_col_w_numeric_vals_in_formula(self):
+        exp_cols = set(['id', '(Intercept)', 'month1',
+                        'month2', 'month4', 'month10'])
+        obs_cols = set()
+
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='month', reference_levels=['month::3'])
+
+        slices = dataloaf.data_slices.iter_views(pd.DataFrame)
+        for _, slice in slices:
+            for col in slice.columns:
+                obs_cols.add(col)
+                self.assertNotIn('month3', col)
 
         self.assertEqual(exp_cols, obs_cols)
 
@@ -170,9 +187,9 @@ class TestANCOMBC(TestBase):
                            reference_levels=['bodysite::tongue',
                                              'month::10'])
 
-        exp_cols = set('id', '(Intercept)', 'bodysitegut',
-                       'bodysiteleft palm', 'bodysiteright palm',
-                       'month1', 'month2', 'month3', 'month4')
+        exp_cols = set(['id', '(Intercept)', 'bodysitegut',
+                        'bodysiteleft palm', 'bodysiteright palm',
+                        'month1', 'month2', 'month3', 'month4'])
 
         slices = dataloaf.data_slices.iter_views(pd.DataFrame)
 

--- a/q2_composition/tests/test_tabulate.py
+++ b/q2_composition/tests/test_tabulate.py
@@ -6,7 +6,15 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import os
+import pandas as pd
+import tempfile
+
 from qiime2.plugin.testing import TestPluginBase
+from qiime2 import Artifact, Metadata
+
+from q2_composition._ancombc import ancombc
+from q2_composition._dataloaf_tabulate._visualizer import tabulate
 
 
 class TestBase(TestPluginBase):
@@ -14,3 +22,91 @@ class TestBase(TestPluginBase):
 
     def setUp(self):
         super().setUp()
+        self.md = Metadata.load(self.get_data_path('sample-md-ancombc.tsv'))
+
+        table = Artifact.load(self.get_data_path('table-ancombc.qza'))
+        self.table = table.view(pd.DataFrame)
+
+
+class TestTabulate(TestBase):
+    def test_intercept_cols_single_formula_no_ref_levels(self):
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite')
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            tabulate(data=dataloaf, output_dir=output_dir)
+            viz_index_fp = os.path.join(output_dir, 'index.html')
+
+            with open(viz_index_fp) as fh:
+                viz_contents = fh.read()
+
+                self.assertTrue('bodysite::gut'
+                                ' (and any numerical metadata columns)'
+                                in viz_contents)
+
+    def test_intercept_cols_single_formula_single_ref_level(self):
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite',
+                           reference_levels='bodysite::tongue')
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            tabulate(data=dataloaf, output_dir=output_dir)
+            viz_index_fp = os.path.join(output_dir, 'index.html')
+
+            with open(viz_index_fp) as fh:
+                viz_contents = fh.read()
+
+                self.assertTrue('bodysite::tongue'
+                                ' (and any numerical metadata columns)'
+                                in viz_contents)
+
+    def test_intercept_cols_multi_formula_no_ref_levels(self):
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite + animal')
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            tabulate(data=dataloaf, output_dir=output_dir)
+            viz_index_fp = os.path.join(output_dir, 'index.html')
+
+            with open(viz_index_fp) as fh:
+                viz_contents = fh.read()
+
+                self.assertTrue('bodysite::gut, animal::bird'
+                                ' (and any numerical metadata columns)'
+                                in viz_contents)
+
+    # TODO: modify behavior to grab any formula term's alpha value if that
+    # column isn't included in the ref levels
+
+    # def test_intercept_cols_multi_formula_single_ref_level(self):
+    #     dataloaf = ancombc(table=self.table, metadata=self.md,
+    #                        formula='bodysite + animal',
+    #                        reference_levels='bodysite::tongue')
+
+    #     with tempfile.TemporaryDirectory() as output_dir:
+    #         tabulate(data=dataloaf, output_dir=output_dir)
+    #         viz_index_fp = os.path.join(output_dir, 'index.html')
+
+    #         with open(viz_index_fp) as fh:
+    #             viz_contents = fh.read()
+
+    #             self.assertTrue('bodysite::tongue, animal::bird'
+    #                             ' (and any numerical metadata columns)'
+    #                             in viz_contents)
+
+    def test_intercept_cols_multi_formula_multi_ref_levels(self):
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite + animal',
+                           reference_levels=['bodysite::tongue',
+                                             'animal::dog'])
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            tabulate(data=dataloaf, output_dir=output_dir)
+            viz_index_fp = os.path.join(output_dir, 'index.html')
+
+            with open(viz_index_fp) as fh:
+                viz_contents = fh.read()
+
+                self.assertTrue('bodysite::tongue, animal::dog'
+                                ' (and any numerical metadata columns)'
+                                in viz_contents)

--- a/q2_composition/tests/test_tabulate.py
+++ b/q2_composition/tests/test_tabulate.py
@@ -75,24 +75,21 @@ class TestTabulate(TestBase):
                                 ' (and any numerical metadata columns)'
                                 in viz_contents)
 
-    # TODO: modify behavior to grab any formula term's alpha value if that
-    # column isn't included in the ref levels
+    def test_intercept_cols_multi_formula_single_ref_level(self):
+        dataloaf = ancombc(table=self.table, metadata=self.md,
+                           formula='bodysite + animal',
+                           reference_levels='bodysite::tongue')
 
-    # def test_intercept_cols_multi_formula_single_ref_level(self):
-    #     dataloaf = ancombc(table=self.table, metadata=self.md,
-    #                        formula='bodysite + animal',
-    #                        reference_levels='bodysite::tongue')
+        with tempfile.TemporaryDirectory() as output_dir:
+            tabulate(data=dataloaf, output_dir=output_dir)
+            viz_index_fp = os.path.join(output_dir, 'index.html')
 
-    #     with tempfile.TemporaryDirectory() as output_dir:
-    #         tabulate(data=dataloaf, output_dir=output_dir)
-    #         viz_index_fp = os.path.join(output_dir, 'index.html')
+            with open(viz_index_fp) as fh:
+                viz_contents = fh.read()
 
-    #         with open(viz_index_fp) as fh:
-    #             viz_contents = fh.read()
-
-    #             self.assertTrue('bodysite::tongue, animal::bird'
-    #                             ' (and any numerical metadata columns)'
-    #                             in viz_contents)
+                self.assertTrue('bodysite::tongue, animal::bird'
+                                ' (and any numerical metadata columns)'
+                                in viz_contents)
 
     def test_intercept_cols_multi_formula_multi_ref_levels(self):
         dataloaf = ancombc(table=self.table, metadata=self.md,

--- a/q2_composition/tests/test_tabulate.py
+++ b/q2_composition/tests/test_tabulate.py
@@ -1,0 +1,16 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2023, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from qiime2.plugin.testing import TestPluginBase
+
+
+class TestBase(TestPluginBase):
+    package = 'q2_composition.tests'
+
+    def setUp(self):
+        super().setUp()


### PR DESCRIPTION
Fixes #115 

This PR adds the following (in addition to the bug fix above):

- Gets default `reference_level` value (if none are included by the user) based on dummy coding for use in tabulate viz.
- Maintains types specified in the input metadata via type directive, so any columns with numeric values that are specified as categorical aren't converted to numeric when passed into R.
- Adds testing for tabulate vis, and the functionality above.