### PR TITLE
BUG: Fixes URL space issue in DA plots 

### DIFF
--- a/q2_composition/_diff_abundance_plots.py
+++ b/q2_composition/_diff_abundance_plots.py
@@ -51,7 +51,7 @@ def _plot_differentials(
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    safe_title = urllib.parse.quote_plus(title)
+    safe_title = urllib.parse.quote(title)
     fig_fn = Path(f'{safe_title}-ancombc-barplot.html')
     fig_fp = output_dir / fig_fn
 

--- a/q2_composition/tests/test_diff_abundance_plot.py
+++ b/q2_composition/tests/test_diff_abundance_plot.py
@@ -28,7 +28,7 @@ class TestBase(TestPluginBase):
 class TestDABarplot(TestBase):
 
     def _get_output_filepath(self, dir, title):
-        safe_title = urllib.parse.quote_plus(title)
+        safe_title = urllib.parse.quote(title)
         return dir / f'{safe_title}-ancombc-barplot.html'
 
     def test_basic_dl1(self):
@@ -45,6 +45,9 @@ class TestDABarplot(TestBase):
 
             right_palm_path = self._get_output_filepath(
                 output_dir, 'bodysiteright palm')
+            print(self._get_output_filepath(
+                output_dir, 'bodysiteright palm'))
+            print(right_palm_path.exists())
             self.assertTrue(right_palm_path.exists())
 
             left_palm_path = self._get_output_filepath(

--- a/q2_composition/tests/test_diff_abundance_plot.py
+++ b/q2_composition/tests/test_diff_abundance_plot.py
@@ -51,11 +51,11 @@ class TestDABarplot(TestBase):
                 output_dir, 'bodysiteleft palm')
             self.assertTrue(left_palm_path.exists())
 
-            #checking that spaces are converted to %20
+            # checking that spaces are converted to %20
             left_palm_path = self._get_output_filepath(
                     output_dir, 'bodysiteleft palm')
             fp = str(left_palm_path)
-            expected_fp_segment="bodysiteleft%20palm-ancombc-barplot.html"
+            expected_fp_segment = "bodysiteleft%20palm-ancombc-barplot.html"
             self.assertIn(expected_fp_segment, fp)
 
             # file shouldn't exist for reference column
@@ -73,7 +73,6 @@ class TestDABarplot(TestBase):
             self.assertTrue(
                 'd29fe3c70564fc0f69f2c03e0d1e5561' in
                 open(left_palm_path).read())
-
 
     def test_basic_dl2(self):
         with tempfile.TemporaryDirectory() as output_dir:

--- a/q2_composition/tests/test_diff_abundance_plot.py
+++ b/q2_composition/tests/test_diff_abundance_plot.py
@@ -51,6 +51,13 @@ class TestDABarplot(TestBase):
                 output_dir, 'bodysiteleft palm')
             self.assertTrue(left_palm_path.exists())
 
+            #checking that spaces are converted to %20
+            left_palm_path = self._get_output_filepath(
+                    output_dir, 'bodysiteleft palm')
+            fp = str(left_palm_path)
+            expected_fp_segment="bodysiteleft%20palm-ancombc-barplot.html"
+            self.assertIn(expected_fp_segment, fp)
+
             # file shouldn't exist for reference column
             gut_path = self._get_output_filepath(
                 output_dir, 'bodysitegut')
@@ -66,6 +73,7 @@ class TestDABarplot(TestBase):
             self.assertTrue(
                 'd29fe3c70564fc0f69f2c03e0d1e5561' in
                 open(left_palm_path).read())
+
 
     def test_basic_dl2(self):
         with tempfile.TemporaryDirectory() as output_dir:

--- a/q2_composition/tests/test_diff_abundance_plot.py
+++ b/q2_composition/tests/test_diff_abundance_plot.py
@@ -45,9 +45,6 @@ class TestDABarplot(TestBase):
 
             right_palm_path = self._get_output_filepath(
                 output_dir, 'bodysiteright palm')
-            print(self._get_output_filepath(
-                output_dir, 'bodysiteright palm'))
-            print(right_palm_path.exists())
             self.assertTrue(right_palm_path.exists())
 
             left_palm_path = self._get_output_filepath(


### PR DESCRIPTION
This PR fixes the issue with URLs breaking if there is a space in the metadata value.  This will address issue https://github.com/qiime2/q2-composition/issues/114

Issue Details: 
The URL's for the subplots have to be double encoded because of q2-view's decoding. The first encoding encoded spaces as `+` and the second encoding encoded spaces as `%20` which are both valid encodings of space. Because of this incompatibility the second encoding was encoding the  `+` as `%2B` because it recognized it as a valid `+` and not an encoding of space. Changing the first encoding so that it encoded spaces as `%20`  to match the second encoding solved this issue. 


