### PR TITLE
BUG: make reference_level column::value separator dynamic based on too many vs too few separators

### DIFF
--- a/q2_composition/_ancombc.py
+++ b/q2_composition/_ancombc.py
@@ -137,21 +137,15 @@ def _ancombc(table, metadata, formula, p_adj_method, prv_cut, lib_cut,
     # column & level validation for the reference_levels parameter
     reference_level_columns = []
     for level in reference_levels:
-        try:
-            column, level_value = level.split('::')
-        except ValueError as e:
-            # More than one ::
-            if 'too many' in str(e):
-                message = 'many'
-            # Zero ::
-            elif 'not enough' in str(e):
-                message = 'few'
-            # Who knows what happened
-            else:
-                raise e
-            raise ValueError('Too %s column-value pair separators found'
+        fields = level.split('::', maxsplit=1)
+
+        if len(fields) == 1:
+            raise ValueError('Too few column-value pair separators found'
                              ' (`::`) in the following `reference_level`:'
-                             ' "%s"' % (message, level)) from e
+                             ' "%s"' % (level))
+
+        column, level_value = fields
+
         # check that multiple values for the same column aren't provided
         if column in reference_level_columns:
             raise ValueError('Multiple `reference_level` pairs with the same'
@@ -164,7 +158,17 @@ def _ancombc(table, metadata, formula, p_adj_method, prv_cut, lib_cut,
             reference_level_columns.append(column)
 
         # check that reference_level columns are present in the metadata
-        ref_column = metadata.get_column(column)
+        try:
+            ref_column = metadata.get_column(column)
+        except ValueError as e:
+            message = str(e)
+
+            if ':' in column:
+                message = ('%s\n\nNOTE: Your column name appears to contain a'
+                           ' `:`, which can be a problem for this action.'
+                           % message)
+
+            raise ValueError(message)
 
         # check that each chosen column contains discrete values
         if isinstance(ref_column, NumericMetadataColumn):
@@ -176,14 +180,18 @@ def _ancombc(table, metadata, formula, p_adj_method, prv_cut, lib_cut,
                             ' %s' % column)
 
         if level_value not in pd.unique(meta[column].values):
-            raise ValueError('Value provided in `reference_levels`'
-                             ' parameter not found in the associated'
-                             ' column within the metadata. Please make'
-                             ' sure each column::value pair is present'
-                             ' within the metadata file.'
-                             ' \n\n'
-                             ' column::value pair with a value that was'
-                             ' not found: "%s"' % level)
+            message = ('Value provided in `reference_levels` parameter not'
+                       ' found in the associated column within the metadata.'
+                       ' Please make sure each column::value pair is present'
+                       ' within the metadata file.\n\n column::value pair with'
+                       ' a value that was not found: "%s"' % level)
+
+            if ':' in level_value:
+                message = ('%s\n\nNOTE: Your level value appears to contain a'
+                           ' `:`, which can be a problem for this action.'
+                           % message)
+
+            raise ValueError(message)
 
         # check that reference_level columns are also in the formula
         if column not in formula_terms:

--- a/q2_composition/_ancombc.py
+++ b/q2_composition/_ancombc.py
@@ -139,10 +139,19 @@ def _ancombc(table, metadata, formula, p_adj_method, prv_cut, lib_cut,
     for level in reference_levels:
         try:
             column, level_value = level.split('::')
-        except Exception:
-            raise ValueError('Too many column-value pair separators found'
+        except ValueError as e:
+            # More than one ::
+            if 'too many' in str(e):
+                message = 'many'
+            # Zero ::
+            elif 'not enough' in str(e):
+                message = 'few'
+            # Who knows what happened
+            else:
+                raise e
+            raise ValueError('Too %s column-value pair separators found'
                              ' (`::`) in the following `reference_level`:'
-                             ' "%s"' % level)
+                             ' "%s"' % (message, level)) from e
         # check that multiple values for the same column aren't provided
         if column in reference_level_columns:
             raise ValueError('Multiple `reference_level` pairs with the same'

--- a/q2_composition/tests/test_ancombc.py
+++ b/q2_composition/tests/test_ancombc.py
@@ -229,8 +229,8 @@ class TestANCOMBC(TestBase):
                     reference_levels=['bodysite::tongue', 'bodysite::toe'])
 
     def test_extra_col_value_separator_in_ref_level_failure(self):
-        with self.assertRaisesRegex(ValueError, 'Too many column-value pair'
-                                    ' separators found.*"bodysite::tongue::"'):
+        with self.assertRaisesRegex(ValueError, '.*tongue::.*\n\nNOTE: Your'
+                                    ' level value appears to contain a `:`.*'):
             ancombc(table=self.table, metadata=self.md, formula='bodysite',
                     reference_levels=['bodysite::tongue::'])
 
@@ -239,3 +239,15 @@ class TestANCOMBC(TestBase):
                                     ' separators found.*"bodysite:tongue"'):
             ancombc(table=self.table, metadata=self.md, formula='bodysite',
                     reference_levels=['bodysite:tongue'])
+
+    def test_colon_in_not_found_column(self):
+        with self.assertRaisesRegex(ValueError, '.*:bodysite.*\n\nNOTE: Your'
+                                    ' column name appears to contain a `:`.*'):
+            ancombc(table=self.table, metadata=self.md, formula='bodysite',
+                    reference_levels=[':bodysite::tongue'])
+
+    def test_colon_in_not_found_level(self):
+        with self.assertRaisesRegex(ValueError, '.*tongue:.*\n\nNOTE: Your'
+                                    ' level value appears to contain a `:`.*'):
+            ancombc(table=self.table, metadata=self.md, formula='bodysite',
+                    reference_levels=['bodysite::tongue:'])

--- a/q2_composition/tests/test_ancombc.py
+++ b/q2_composition/tests/test_ancombc.py
@@ -233,3 +233,9 @@ class TestANCOMBC(TestBase):
                                     ' separators found.*"bodysite::tongue::"'):
             ancombc(table=self.table, metadata=self.md, formula='bodysite',
                     reference_levels=['bodysite::tongue::'])
+
+    def test_no_col_value_separator_in_ref_level_failure(self):
+        with self.assertRaisesRegex(ValueError, 'Too few column-value pair'
+                                    ' separators found.*"bodysite:tongue"'):
+            ancombc(table=self.table, metadata=self.md, formula='bodysite',
+                    reference_levels=['bodysite:tongue'])


### PR DESCRIPTION
Closes #119 by making the error message dynamic based on number of separators