### PR TITLE
require user to define the level delimiter

### DIFF
--- a/q2_composition/_diff_abundance_plots.py
+++ b/q2_composition/_diff_abundance_plots.py
@@ -67,8 +67,13 @@ def _plot_differentials(
         y_labels = []
         seen = Counter()
         for i, e in enumerate(df[feature_id_label]):
-            fields = [field for field in e.split(level_delimiter)
-                      if not field.endswith('__')]
+            if level_delimiter in e:
+                fields = [field for field in e.split(level_delimiter)
+                          if not field.endswith('__')]
+            else:
+                # this is necessary to handle a case where the delimiter
+                # isn't found and the e ends with '__'
+                fields = [e]
             most_specific = fields[-1]
             if most_specific in seen:
                 y_labels.append(f"{seen[most_specific]}: {most_specific} *")

--- a/q2_composition/_diff_abundance_plots.py
+++ b/q2_composition/_diff_abundance_plots.py
@@ -29,7 +29,8 @@ def _plot_differentials(
         error_label,
         feature_ids,
         effect_size_threshold,
-        significance_threshold):
+        significance_threshold,
+        level_delimiter):
 
     if len(df) == 0:
         raise ValueError("No features present in input.")
@@ -55,26 +56,31 @@ def _plot_differentials(
     fig_fn = Path(f'{safe_title}-ancombc-barplot.html')
     fig_fp = output_dir / fig_fn
 
-    # For readability, only the most specific named taxonomy will be
-    # included in the y-axis label. The full taxonomy text will be in
-    # the tool-tip. Because it's possible that the most specific
-    # taxonomic name are not unique, this code simply prepends a number
-    # to names. Providing separate labels for ticks, which
-    # would avoid this, doesn't seem straight-forward in altair (e.g.,
-    # see https://github.com/altair-viz/altair/issues/938).
-    y_labels = []
-    seen = Counter()
-    for i, e in enumerate(df[feature_id_label]):
-        fields = [field for field in e.split(';') if not field.endswith('__')]
-        most_specific = fields[-1]
-        if most_specific in seen:
-            y_labels.append(f"{seen[most_specific]}: {most_specific} *")
-        else:
-            y_labels.append(most_specific)
-        seen[most_specific] += 1
-    df['y_label'] = y_labels
+    if level_delimiter is not None:
+        # For readability, only the most specific named taxonomy will be
+        # included in the y-axis label. The full taxonomy text will be in
+        # the tool-tip. Because it's possible that the most specific
+        # taxonomic name are not unique, this code simply prepends a number
+        # to names. Providing separate labels for ticks, which
+        # would avoid this, doesn't seem straight-forward in altair (e.g.,
+        # see https://github.com/altair-viz/altair/issues/938).
+        y_labels = []
+        seen = Counter()
+        for i, e in enumerate(df[feature_id_label]):
+            fields = [field for field in e.split(level_delimiter)
+                      if not field.endswith('__')]
+            most_specific = fields[-1]
+            if most_specific in seen:
+                y_labels.append(f"{seen[most_specific]}: {most_specific} *")
+            else:
+                y_labels.append(most_specific)
+            seen[most_specific] += 1
+        df['y_label'] = y_labels
+        df['feature'] = [id_.replace(level_delimiter, ' ')
+                         for id_ in df[feature_id_label]]
+    else:
+        df['y_label'] = df['feature'] = df[feature_id_label]
 
-    df['feature'] = [id_.replace(';', ' ') for id_ in df[feature_id_label]]
     df['enriched'] = ["enriched" if x else "depleted"
                       for x in df[effect_size_label] > 0]
 
@@ -126,7 +132,8 @@ def da_barplot(output_dir: str,
                significance_label: str = 'q_val',
                significance_threshold: float = 1.0,
                effect_size_threshold: float = 0.0,
-               feature_ids: qiime2.Metadata = None):
+               feature_ids: qiime2.Metadata = None,
+               level_delimiter: str = None):
 
     # setup for the index.html page
     ASSETS = pkg_resources.resource_filename('q2_composition',
@@ -205,7 +212,8 @@ def da_barplot(output_dir: str,
                 significance_label=significance_label,
                 significance_threshold=significance_threshold,
                 effect_size_threshold=effect_size_threshold,
-                feature_ids=feature_ids)
+                feature_ids=feature_ids,
+                level_delimiter=level_delimiter)
             figure_fn = figure_fp.parts[-1]
             figure_data.append((True, figure_fn, column_label, None))
         except ValueError as e:

--- a/q2_composition/plugin_setup.py
+++ b/q2_composition/plugin_setup.py
@@ -196,7 +196,7 @@ plugin.visualizers.register_function(
                                   "of effect size less than this threshold."),
         'feature_ids': ("Exclude features if their ids are not included in "
                         "this index."),
-        'level_delimiter': ("If feature ids encode heirarchical information, "
+        'level_delimiter': ("If feature ids encode hierarchical information, "
                             "split the levels when generating feature labels "
                             "in the visualization using this delimiter.")},
     name='Differential abundance bar plots',

--- a/q2_composition/plugin_setup.py
+++ b/q2_composition/plugin_setup.py
@@ -180,7 +180,8 @@ plugin.visualizers.register_function(
                                                         inclusive_end=True),
                 'effect_size_threshold': Float % Range(0.0, np.inf,
                                                        inclusive_start=True),
-                'feature_ids': Metadata},
+                'feature_ids': Metadata,
+                'level_delimiter': Str},
     input_descriptions={'data': 'The ANCOM-BC output to be plotted.'},
     parameter_descriptions={
         'effect_size_label': "Label for effect sizes in `data`.",
@@ -194,7 +195,10 @@ plugin.visualizers.register_function(
         'effect_size_threshold': ("Exclude features with an absolute value "
                                   "of effect size less than this threshold."),
         'feature_ids': ("Exclude features if their ids are not included in "
-                        "this index.")},
+                        "this index."),
+        'level_delimiter': ("If feature ids encode heirarchical information, "
+                            "split the levels when generating feature labels "
+                            "in the visualization using this delimiter.")},
     name='Differential abundance bar plots',
     description=('Generate bar plot views of ANCOM-BC output. One plot will '
                  'be present per column in the ANCOM-BC output. The '

--- a/q2_composition/tests/test_diff_abundance_plot.py
+++ b/q2_composition/tests/test_diff_abundance_plot.py
@@ -340,3 +340,156 @@ class TestDABarplot(TestBase):
                 da_barplot(output_dir,
                            data=self.dataloaf1.view(DataLoafPackageDirFmt),
                            error_label='stderr')
+
+    def test_toggle_level_delimiter(self):
+        # no delimiter
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_dir = Path(output_dir)
+            _ = da_barplot(output_dir,
+                           self.dataloaf2.view(DataLoafPackageDirFmt))
+
+            feces_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:feces')
+            self.assertTrue(feces_path.exists())
+
+            oral_cavity_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:oral cavity')
+            self.assertTrue(oral_cavity_path.exists())
+
+            saliva_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:saliva')
+            self.assertTrue(saliva_path.exists())
+
+            vagina_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:vagina')
+            self.assertTrue(vagina_path.exists())
+
+            # multi-level information should be present as y-label
+            self.assertTrue(
+                '"y_label": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(feces_path).read())
+            self.assertTrue(
+                '"y_label": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(oral_cavity_path).read())
+            self.assertTrue(
+                '"y_label": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(saliva_path).read())
+            self.assertTrue(
+                '"y_label": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(vagina_path).read())
+
+            # same labels should be present as 'feature'
+            self.assertTrue(
+                '"feature": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(feces_path).read())
+            self.assertTrue(
+                '"feature": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(oral_cavity_path).read())
+            self.assertTrue(
+                '"feature": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(saliva_path).read())
+            self.assertTrue(
+                '"feature": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(vagina_path).read())
+
+        # typical delimiter: ;
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_dir = Path(output_dir)
+            _ = da_barplot(output_dir,
+                           self.dataloaf2.view(DataLoafPackageDirFmt),
+                           level_delimiter=';')
+
+            feces_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:feces')
+            self.assertTrue(feces_path.exists())
+
+            oral_cavity_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:oral cavity')
+            self.assertTrue(oral_cavity_path.exists())
+
+            saliva_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:saliva')
+            self.assertTrue(saliva_path.exists())
+
+            vagina_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:vagina')
+            self.assertTrue(vagina_path.exists())
+
+            # single-level information should be present as 'y-label'
+            self.assertTrue(
+                '"y_label": "g__Staphylococcus' in
+                open(feces_path).read())
+            self.assertTrue(
+                '"y_label": "g__Staphylococcus' in
+                open(oral_cavity_path).read())
+            self.assertTrue(
+                '"y_label": "g__Staphylococcus' in
+                open(saliva_path).read())
+            self.assertTrue(
+                '"y_label": "g__Staphylococcus' in
+                open(vagina_path).read())
+
+            # space delimited labels should be present as 'feature'
+            self.assertTrue(
+                '"feature": "d__Bacteria p__Firmicutes c__Bacilli o__Staphylococcales f__Staphylococcaceae g__Staphylococcus"'  # noqa: E501
+                in open(feces_path).read())
+            self.assertTrue(
+                '"feature": "d__Bacteria p__Firmicutes c__Bacilli o__Staphylococcales f__Staphylococcaceae g__Staphylococcus"'  # noqa: E501
+                in open(oral_cavity_path).read())
+            self.assertTrue(
+                '"feature": "d__Bacteria p__Firmicutes c__Bacilli o__Staphylococcales f__Staphylococcaceae g__Staphylococcus"'  # noqa: E501
+                in open(saliva_path).read())
+            self.assertTrue(
+                '"feature": "d__Bacteria p__Firmicutes c__Bacilli o__Staphylococcales f__Staphylococcaceae g__Staphylococcus"'  # noqa: E501
+                in open(vagina_path).read())
+
+        # weird delimiter: __
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_dir = Path(output_dir)
+            _ = da_barplot(output_dir,
+                           self.dataloaf2.view(DataLoafPackageDirFmt),
+                           level_delimiter='__')
+
+            feces_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:feces')
+            self.assertTrue(feces_path.exists())
+
+            oral_cavity_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:oral cavity')
+            self.assertTrue(oral_cavity_path.exists())
+
+            saliva_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:saliva')
+            self.assertTrue(saliva_path.exists())
+
+            vagina_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:vagina')
+            self.assertTrue(vagina_path.exists())
+
+            # single-level information should be present as 'y-label'
+            self.assertTrue(
+                '"y_label": "Staphylococcus' in
+                open(feces_path).read())
+            self.assertTrue(
+                '"y_label": "Staphylococcus' in
+                open(oral_cavity_path).read())
+            self.assertTrue(
+                '"y_label": "Staphylococcus' in
+                open(saliva_path).read())
+            self.assertTrue(
+                '"y_label": "Staphylococcus' in
+                open(vagina_path).read())
+
+            # space delimited labels should be present as 'feature'
+            self.assertTrue(
+                '"feature": "d Bacteria;p Firmicutes;c Bacilli;o Staphylococcales;f Staphylococcaceae;g Staphylococcus"'  # noqa: E501
+                in open(feces_path).read())
+            self.assertTrue(
+                '"feature": "d Bacteria;p Firmicutes;c Bacilli;o Staphylococcales;f Staphylococcaceae;g Staphylococcus"'  # noqa: E501
+                in open(oral_cavity_path).read())
+            self.assertTrue(
+                '"feature": "d Bacteria;p Firmicutes;c Bacilli;o Staphylococcales;f Staphylococcaceae;g Staphylococcus"'  # noqa: E501
+                in open(saliva_path).read())
+            self.assertTrue(
+                '"feature": "d Bacteria;p Firmicutes;c Bacilli;o Staphylococcales;f Staphylococcaceae;g Staphylococcus"'  # noqa: E501
+                in open(vagina_path).read())

--- a/q2_composition/tests/test_diff_abundance_plot.py
+++ b/q2_composition/tests/test_diff_abundance_plot.py
@@ -493,3 +493,54 @@ class TestDABarplot(TestBase):
             self.assertTrue(
                 '"feature": "d Bacteria;p Firmicutes;c Bacilli;o Staphylococcales;f Staphylococcaceae;g Staphylococcus"'  # noqa: E501
                 in open(vagina_path).read())
+
+        # missing delimiter: !
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_dir = Path(output_dir)
+            _ = da_barplot(output_dir,
+                           self.dataloaf2.view(DataLoafPackageDirFmt),
+                           level_delimiter='!')
+
+            feces_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:feces')
+            self.assertTrue(feces_path.exists())
+
+            oral_cavity_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:oral cavity')
+            self.assertTrue(oral_cavity_path.exists())
+
+            saliva_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:saliva')
+            self.assertTrue(saliva_path.exists())
+
+            vagina_path = self._get_output_filepath(
+                output_dir, 'body_habitatUBERON:vagina')
+            self.assertTrue(vagina_path.exists())
+
+            # multi-level information should be present as 'y-label'
+            self.assertTrue(
+                '"y_label": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(feces_path).read())
+            self.assertTrue(
+                '"y_label": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(oral_cavity_path).read())
+            self.assertTrue(
+                '"y_label": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(saliva_path).read())
+            self.assertTrue(
+                '"y_label": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(vagina_path).read())
+
+            # same labels should be present as 'feature'
+            self.assertTrue(
+                '"feature": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(feces_path).read())
+            self.assertTrue(
+                '"feature": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(oral_cavity_path).read())
+            self.assertTrue(
+                '"feature": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(saliva_path).read())
+            self.assertTrue(
+                '"feature": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
+                in open(vagina_path).read())

--- a/q2_composition/tests/test_diff_abundance_plot.py
+++ b/q2_composition/tests/test_diff_abundance_plot.py
@@ -364,7 +364,7 @@ class TestDABarplot(TestBase):
                 output_dir, 'body_habitatUBERON:vagina')
             self.assertTrue(vagina_path.exists())
 
-            # multi-level information should be present as y-label
+            # multi-level information should be present as 'y-label'
             self.assertTrue(
                 '"y_label": "d__Bacteria;p__Firmicutes;c__Bacilli;o__Staphylococcales;f__Staphylococcaceae;g__Staphylococcus"'  # noqa: E501
                 in open(feces_path).read())


### PR DESCRIPTION
Fixes #121 

This is a breaking change! Note for change log:

```
@gregcaporaso addressed an issue in q2-composition da-barplot where the visualization made 
assumptions about the feature id schema. The split feature ids on semi-colons for readability in 
figures, users should now provide the `--p-level-delimiter ';'` parameter (where previously this 
was not required).
```