### PR TITLE
imp: consistent da_barplot color scheme

### DIFF
--- a/q2_composition/_diff_abundance_plots.py
+++ b/q2_composition/_diff_abundance_plots.py
@@ -110,6 +110,9 @@ def _plot_differentials(
                              significance_label, error_label,
                              "error-lower", "error-upper"]),
         color=alt.Color('enriched', title="Relative to reference",
+                        scale=alt.Scale(
+                            domain=["enriched", "depleted"],
+                            range=["#4c78a8", "#f58518"]),
                         sort="descending")
     )
 


### PR DESCRIPTION
Closes #137 (I hope so!)

Now a color scale in `da_barplot` is specified, mapping "enriched" to #4c78a8 and "depleted" to #f58518 (these are the colors used in the default Vega Color Scheme for Nominal fields, [`#tableau10`](https://vega.github.io/vega/docs/schemes/#tableau10)).


