### PR TITLE
Adding option to sort taxa on absolute value of lfc

### DIFF
--- a/q2_composition/_ancombc2_visualizer/src/lib/BarplotFilters.svelte
+++ b/q2_composition/_ancombc2_visualizer/src/lib/BarplotFilters.svelte
@@ -60,6 +60,8 @@
     function getSymbol(relationship: string) {
         if (relationship == "gt") return ">";
         if (relationship == "lt") return "<";
+        if (relationship == 'gtabsval') return "> (abs)";
+        if (relationship == 'ltabsval') return "< (abs)";
     }
 
     function remove(slice: string, relationship: string, value: number) {
@@ -101,6 +103,8 @@
             >
                 <option value="gt">greater than</option>
                 <option value="lt">less than</option>
+                <option value='gtabsval'>greater than (absolute value)</option>
+                <option value='ltabsval'>less than (absolute value)</option>
             </select>
         </div>
         <div class="grid grid-cols-subgrid col-span-2">

--- a/q2_composition/_ancombc2_visualizer/src/util/features.svelte.ts
+++ b/q2_composition/_ancombc2_visualizer/src/util/features.svelte.ts
@@ -189,6 +189,8 @@ export class FeatureRecords {
 
             if (relationship == "gt") return variableValue > value;
             if (relationship == "lt") return variableValue < value;
+            if (relationship == 'gtabsval') return Math.abs(variableValue) > value;
+            if (relationship == 'ltabsval') return Math.abs(variableValue) < value;
 
             throw new Error(`Unexpected relationship ${relationship}.`);
         };


### PR DESCRIPTION
Adds `greater than (absolute value)` and `less than (absolute value)` options when filtering `ancombc2-visualizer`.
Resolves #157 